### PR TITLE
Fixed logic error in base pthread example.

### DIFF
--- a/examples/pthreads/pt_basic.c
+++ b/examples/pthreads/pt_basic.c
@@ -12,7 +12,7 @@ void *function( void *ptr ) {
 	char *message;
 	message = (char *) ptr;
 	printf("Hello from %s \n", message);
-	pthread_exit(0);
+	pthread_exit(0);                        // to return custom value, typecast must be done explicitly: pthread_exit((void*)3);
 }
 
 int main(void) {
@@ -23,15 +23,15 @@ int main(void) {
 
 	/* Create independent threads each of which will execute function */
 
-	iret1 = pthread_create( &thread1, NULL, &function, (void*) message1);
-	iret2 = pthread_create( &thread2, NULL, &function, (void*) message2);
+	pthread_create( &thread1, NULL, &function, (void*) message1);
+	pthread_create( &thread2, NULL, &function, (void*) message2);
 
 	/* Wait until threads are complete before main continues. Unless we */
 	/* wait we run the risk of executing an exit which will terminate   */
 	/* the process and all threads before the threads have completed.   */
 
-	pthread_join( thread1, NULL);
-	pthread_join( thread2, NULL);
+	pthread_join( thread1, (void**)&iret1); // int variable casted to void* was passed to pthread_exit, now we pass address of int variable
+	pthread_join( thread2, (void**)&iret2); // function argument would be int* so that int variable passed by address is filled, we just use void* instead of int here
 
 	printf("Thread 1 returns: %d\n",iret1);
 	printf("Thread 2 returns: %d\n",iret2);

--- a/examples/pthreads/pt_condition3.c
+++ b/examples/pthreads/pt_condition3.c
@@ -9,100 +9,99 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #define NUM_THREADS  3
 #define TCOUNT 10
 #define COUNT_LIMIT 12
 
-int     count = 0;
+int             count = 0;
 pthread_mutex_t count_mutex;
-pthread_cond_t count_threshold_cv;
+pthread_cond_t  count_threshold_cv;
 
 void *inc_count(void *t)
 {
-  int j,i;
-  double result=0.0;
-  int my_id = (int)t;
+    int i;
+    int my_id = (int)t;
 
-  for (i=0; i < TCOUNT; i++) {
-    pthread_mutex_lock(&count_mutex);
-    count++;
+    for (i=0; i < TCOUNT; i++)
+    {
 
-    /*
-    Check the value of count and signal waiting thread when condition is
-    reached.  Note that this occurs while mutex is locked.
-    */
-    if (count == COUNT_LIMIT) {
-      printf("inc_count(): thread %d, count = %d  Threshold reached. ",
-             my_id, count);
-      pthread_cond_signal(&count_threshold_cv);
-      printf("Just sent signal.\n");
-      }
-    printf("inc_count(): thread %d, count = %d, unlocking mutex\n",
-	   my_id, count);
-    pthread_mutex_unlock(&count_mutex);
+        pthread_mutex_lock(&count_mutex);
+        count++;
+        /*
+        Check the value of count and signal waiting thread when condition is
+        reached.  Note that this occurs while mutex is locked.
+        */
+        if (count == COUNT_LIMIT)
+        {
+            printf("inc_count(): thread %d, count = %d  Threshold reached.", my_id, count);
+            pthread_cond_signal(&count_threshold_cv);
+            printf("Just sent signal.\n");
+        }
+        printf("inc_count(): thread %d, count = %d, unlocking mutex\n", my_id, count);
+        pthread_mutex_unlock(&count_mutex);
 
-    /* Do some work so threads can alternate on mutex lock */
-    for (j=0; j < 1000; j++)
-      result = result + (double)rand();
+        Sleep(1); // suspends this thread to prevent mutex being locked by the same thread again
     }
-  pthread_exit(NULL);
+
+    pthread_exit(NULL);
 }
 
 void *watch_count(void *t)
 {
-  int my_id = (int)t;
+    int my_id = (int)t;
 
-  printf("Starting watch_count(): thread %d\n", my_id);
+    printf("Starting watch_count(): thread %d\n", my_id);
 
-  /*
-  Lock mutex and wait for signal.  Note that the pthread_cond_wait routine
-  will automatically and atomically unlock mutex while it waits.
-  Also, note that if COUNT_LIMIT is reached before this routine is run by
-  the waiting thread, the loop will be skipped to prevent pthread_cond_wait
-  from never returning.
-  */
-  pthread_mutex_lock(&count_mutex);
-  if (count < COUNT_LIMIT) {
-    printf("watch_count(): thread %d going into wait...\n", my_id);
-    pthread_cond_wait(&count_threshold_cv, &count_mutex);
-    printf("watch_count(): thread %d Condition signal received.\n", my_id);
-    count += 125;
-    printf("watch_count(): thread %d count now = %d.\n", my_id, count);
+    /*
+    Lock mutex and wait for signal.  Note that the pthread_cond_wait routine
+    will automatically and atomically unlock mutex while it waits.
+    Also, note that if COUNT_LIMIT is reached before this routine is run by
+    the waiting thread, the loop will be skipped to prevent pthread_cond_wait
+    from never returning.
+    */
+    pthread_mutex_lock(&count_mutex);
+    if (count < COUNT_LIMIT)
+    {
+        printf("watch_count(): thread %d going into wait...\n", my_id);
+        pthread_cond_wait(&count_threshold_cv, &count_mutex);
+        printf("watch_count(): thread %d Condition signal received.\n", my_id);
+        count += 125;
+        printf("watch_count(): thread %d count now = %d.\n", my_id, count);
     }
-  pthread_mutex_unlock(&count_mutex);
-  pthread_exit(NULL);
+    pthread_mutex_unlock(&count_mutex);
+    pthread_exit(NULL);
 }
 
 int main(int argc, char *argv[])
 {
-  int i, t1=1, t2=2, t3=3;
-  pthread_t threads[3];
-  pthread_attr_t attr;
+    int i, t1=1, t2=2, t3=3;
+    pthread_t threads[3];
+    pthread_attr_t attr;
 
-  /* Initialize mutex and condition variable objects */
-  pthread_mutex_init(&count_mutex, NULL);
-  pthread_cond_init (&count_threshold_cv, NULL);
+    /* Initialize mutex and condition variable objects */
+    pthread_mutex_init(&count_mutex, NULL);
+    pthread_cond_init (&count_threshold_cv, NULL);
 
-  /* For portability, explicitly create threads in a joinable state */
-  pthread_attr_init(&attr);
-  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-  pthread_create(&threads[2], &attr, watch_count, (void *)t3);
-  pthread_create(&threads[0], &attr, inc_count, (void *)t1);
-  pthread_create(&threads[1], &attr, inc_count, (void *)t2);
+    /* For portability, explicitly create threads in a joinable state */
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+    pthread_create(&threads[2], &attr, watch_count, (void *)t3);
+    pthread_create(&threads[0], &attr, inc_count, (void *)t1);
+    pthread_create(&threads[1], &attr, inc_count, (void *)t2);
 
-  /* Wait for all threads to complete */
-  for (i = 0; i < NUM_THREADS; i++) {
-    pthread_join(threads[i], NULL);
-  }
-  printf ("Main(): Waited on %d threads. Final value of count = %d. Done.\n",
-          NUM_THREADS, count);
+    /* Wait for all threads to complete */
+    for (i = 0; i < NUM_THREADS; i++)
+    {
+        pthread_join(threads[i], NULL);
+    }
+    printf ("Main(): Waited on %d threads. Final value of count = %d. Done.\n", NUM_THREADS, count);
 
-  /* Clean up and exit */
-  pthread_attr_destroy(&attr);
-  pthread_mutex_destroy(&count_mutex);
-  pthread_cond_destroy(&count_threshold_cv);
-  pthread_exit (NULL);
+    /* Clean up and exit */
+    pthread_attr_destroy(&attr);
+    pthread_mutex_destroy(&count_mutex);
+    pthread_cond_destroy(&count_threshold_cv);
 
+    exit(0);
 }
-


### PR DESCRIPTION
Return value of thread should be printed instead of return code of pthread_create function call.
