### PR TITLE
Remove -fopenmp compiler flag

### DIFF
--- a/examples/opengl/Makefile
+++ b/examples/opengl/Makefile
@@ -7,7 +7,7 @@
 #
 
 CC		= gcc
-CFLAGS	= -O3 -Wall -fopenmp
+CFLAGS	= -O3 -Wall
 UNAME := $(shell uname -s)
 
 ALL =   gl_gradient gl_projection gl_transformation gl_vbo gl_light


### PR DESCRIPTION
OpenMP is not used in OpenGL examples.
Prevents errors on OS X, because Xcode 5 does not bundle GCC anymore, and Clang compiler does not support OpenMP yet.

See: 
http://stackoverflow.com/a/13720279/1716747
http://stackoverflow.com/a/17164844/1716747

Also, OpenMP will be supported in Clang/Xcode eventually, but it is not merged yet:
http://clang-omp.github.io/
